### PR TITLE
Update 

### DIFF
--- a/core/Climate+Weather/NEW_DATASET.yml
+++ b/core/Climate+Weather/NEW_DATASET.yml
@@ -1,0 +1,31 @@
+---
+title: Average city temperatures
+homepage: https://www.fetchseries.com/climate/average-city-temperatures-fsr/
+category: Climate+Weather
+description: Contains daily time series of average air temperatures in about 2000 large cities around the world. The time series are updated daily. 
+version: 1.0
+keywords: temperatures, climate.
+image: 
+temporal:
+spatial: 
+access_level: public
+copyrights: 
+accrual_periodicity: 
+specification:
+data_quality: false
+data_dictionary: 
+language: en
+license: Creative Commons Attribution 4.0 International (CC BY 4.0)
+publisher:
+  - name: FetchSeries Research
+    web: https://www.fetchseries.com
+organization:
+  - name: 
+    web: 
+issued_time: 
+sources:
+  - name: 
+    access_url: 
+references:
+  - title: 
+    reference: 

--- a/core/Economics/prop-metrics-real-estate-data.yml
+++ b/core/Economics/prop-metrics-real-estate-data.yml
@@ -1,7 +1,7 @@
 ---
 title: Prop-Metrics — U.S. ZIP-Code-Level Real Estate Analytics Dataset
 homepage: https://www.prop-metrics.com
-category: RealEstate
+category: Economics
 description: >
   A comprehensive dataset providing ZIP-code-level real estate, rental, demographic,
   and mortgage market analytics across the United States. Prop-Metrics aggregates

--- a/core/Economics/prop-metrics-real-estate-data.yml
+++ b/core/Economics/prop-metrics-real-estate-data.yml
@@ -1,0 +1,56 @@
+---
+title: Prop-Metrics — U.S. ZIP-Code-Level Real Estate Analytics Dataset
+homepage: https://www.prop-metrics.com
+category: RealEstate
+description: >
+  A comprehensive dataset providing ZIP-code-level real estate, rental, demographic,
+  and mortgage market analytics across the United States. Prop-Metrics aggregates
+  and normalizes open data from Zillow, Realtor.com, the U.S. Census Bureau (ACS),
+  HUD Section 8 payment standards, and HMDA mortgage disclosures to produce unified
+  time-series metrics such as median home values, rental trends, income-to-price
+  ratios, investor loan shares, and Section 8 coverage rates.
+version: 1.0
+keywords:
+  - real estate
+  - housing market
+  - rentals
+  - demographics
+  - mortgage data
+  - Section 8
+  - ZIP code analytics
+image: https://i.ibb.co/683QvpX/prop-metrics-twitter.png
+temporal: 2005-present (monthly to annual updates depending on source)
+spatial: U.S. ZIP Code Tabulation Areas (ZCTAs)
+access_level: public
+copyrights: >
+  © Prop-Metrics 2025. Derived data compiled from publicly available
+  and licensed open-data sources under their respective usage terms.
+accrual_periodicity: monthly, yearly
+specification: >
+  Metrics stored in wide-format tables keyed by (zcta, metric, date). Each record contains standardized
+  metric identifiers, value, and freshness metadata.
+data_quality: true
+data_dictionary: https://www.prop-metrics.com/about#download-data
+language: en
+license: CC BY 4.0
+publisher:
+  - name: Prop-Metrics
+    web: https://www.prop-metrics.com
+organization:
+  - name: Prop-Metrics Analytics, LLC
+    web: https://www.prop-metrics.com
+issued_time: 2025-10
+sources:
+  - name: Zillow Home Value Index (ZHVI) & Zillow Observed Rent Index (ZORI)
+    access_url: https://www.zillow.com/research/data/
+  - name: Realtor.com Monthly Market Data
+    access_url: https://www.realtor.com/research/data/
+  - name: U.S. Census Bureau — American Community Survey (ACS)
+    access_url: https://www.census.gov/programs-surveys/acs
+  - name: HUD Fair Market Rents & Section 8 Payment Standards
+    access_url: https://www.huduser.gov/portal/datasets/fmr.html
+  - name: Home Mortgage Disclosure Act (HMDA)
+    access_url: https://ffiec.cfpb.gov/data-publication
+references:
+  - title: Prop-Metrics ZIP-Code Analytics Overview
+    reference: https://www.prop-metrics.com/about

--- a/core/Healthcare/MeSH-the-vocabulary-thesaurus-used-for-indexing-articles-for-PubMed.yml
+++ b/core/Healthcare/MeSH-the-vocabulary-thesaurus-used-for-indexing-articles-for-PubMed.yml
@@ -1,8 +1,8 @@
 ---
 title: MeSH, the vocabulary thesaurus used for indexing articles for PubMed
-homepage: https://www.nlm.nih.gov/mesh/filelist.html
+homepage: https://www.nlm.nih.gov/mesh/meshhome.html
 category: Healthcare
-description:
+description: Check under 'Obtain MeSH Data'
 version:
 keywords:
 image:

--- a/core/Healthcare/Medicare-Data-Engine-of-medicare.gov-Data.yml
+++ b/core/Healthcare/Medicare-Data-Engine-of-medicare.gov-Data.yml
@@ -1,6 +1,6 @@
 ---
 title: Medicare Data Engine of medicare.gov Data
-homepage: https://data.medicare.gov/
+homepage: https://data.cms.gov
 category: Healthcare
 description:
 version:

--- a/core/Healthcare/Open-ODS.yml
+++ b/core/Healthcare/Open-ODS.yml
@@ -1,6 +1,6 @@
 ---
 title: Open-ODS (structure of the UK NHS)
-homepage: http://www.openods.co.uk
+homepage: https://www.odsdatasearchandexport.nhs.uk/
 category: Healthcare
 description:
 version:
@@ -13,7 +13,7 @@ copyrights:
 accrual_periodicity:
 specification:
 data_quality: false
-data_dictionary:
+data_dictionary: https://www.odsdatasearchandexport.nhs.uk/referenceDataCatalogue/index.html
 language:
 license:
 publisher:

--- a/core/ImageProcessing/AI-Detector-Arena-Benchmark.yml
+++ b/core/ImageProcessing/AI-Detector-Arena-Benchmark.yml
@@ -1,0 +1,28 @@
+---
+title: AI Detector Arena Benchmark
+homepage: https://aidetectarena.com/benchmark-dataset
+category: ImageProcessing
+description: "A standardized benchmark dataset for evaluating AI-generated image detection tools. Contains 2,038 images with balanced split between AI-generated (1,018) and real photos (1,020). Covers 17 state-of-the-art AI generators including DALL-E 3, Midjourney, Stable Diffusion, and Flux. Images span 6 categories: Portrait, Landscape, Art, Food, Animal, and Product. Includes full metadata, evaluation scripts, and versioned releases for reproducible research. Features a live leaderboard comparing detector performance."
+version: "0.1"
+keywords: AI detection, deepfake detection, synthetic image detection, computer vision, benchmark, machine learning
+image: 
+temporal: false
+spatial: false
+access_level: public
+copyrights: CC-BY-4.0
+accrual_periodicity: 
+specification: https://aidetectarena.com/methodology
+data_quality: true
+data_dictionary: https://aidetectarena.com/benchmark-dataset
+language: en
+license: CC-BY-4.0
+publisher:
+  - AI Detector Arena
+organization:
+  - AI Detector Arena
+issued_time: 2026.02
+sources:
+  - Unsplash (real photos)
+  - Official AI generator APIs
+references:
+  - https://doi.org/10.5281/zenodo.18620634


### PR DESCRIPTION
---
title: 38-Cloud
homepage: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset
category: EarthScience
description: Contains 38 Landsat 8 scene images and their manually extracted pixel-level ground truths for cloud detection. They are cropped into multiple 384*384 patches. It has 8400 patches for training and 9201 patches for testing.
version: 1.0
keywords: Landsat 8, cloud detection, image segmentation, semantic segmentation.
image: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset/blob/master/sample/blue_patch_192_10_by_12_LC08_L1TP_002053_20160520_20170324_01_T1.jpg
temporal:
spatial: 384*384
access_level: public
copyrights:
accrual_periodicity: 
specification:
data_quality: false
data_dictionary: 
language: en
license: Apache License
publisher:
  - name: 
    web: 
organization:
  - name: Laboratory for Robotic Vision (LRV), School of Engineering Science, Simon Fraser University, Canada
    web: 
issued_time: 2019.02
sources:
  - name: 
    access_url: 
references:
  - title: 
    reference: 
