### PR TITLE
Catch up 

### DIFF
--- a/core/Economics/Property-Comps.yml
+++ b/core/Economics/Property-Comps.yml
@@ -1,0 +1,64 @@
+---
+title: Property Comps — Comparable Property Sales Across 11 Global Markets
+homepage: https://api.nwc-advisory.com/docs
+category: Economics
+description: >
+  Free API providing 44M+ property transactions from official government registries
+  across 11 markets: UK (HM Land Registry), France (DVF), Singapore (HDB),
+  NYC, Chicago, Miami, Philadelphia, Connecticut (DOF/assessor), Dubai (DLD),
+  Ireland (Property Price Register), and Taiwan (Ministry of Interior).
+  Search comparable sales by location and radius, filter by property type,
+  get area statistics (median, percentile, price per sqft/m2), and monthly trends.
+  OpenAPI 3.1 spec with Swagger UI. No authentication required for docs and market listing.
+version: 1.0
+keywords:
+  - real estate
+  - property prices
+  - comparable sales
+  - housing market
+  - government data
+  - open data
+  - property transactions
+  - global markets
+temporal: 2000-present (varies by market, updated monthly)
+spatial: 11 countries/cities (UK, France, Singapore, NYC, Chicago, Miami, Philadelphia, Connecticut, Dubai, Ireland, Taiwan)
+access_level: public
+copyrights: >
+  Data sourced from official government open data registries under their respective
+  open data licenses (OGL, Licence Ouverte, data.gov.sg, NYC Open Data).
+accrual_periodicity: monthly
+specification: >
+  RESTful JSON API. Three endpoints: /v1/comps (comparable sales search),
+  /v1/stats (area statistics), /v1/trends (monthly price trends).
+  Each market uses its native location parameter (postcode, code_postal, zip_code, area_name).
+data_quality: true
+data_dictionary: https://api.nwc-advisory.com/openapi.json
+language: en
+license: Open Data (varies by source registry)
+publisher:
+  - name: New Way Capital Advisory
+    web: https://nwc-advisory.com
+organization:
+  - name: New Way Capital Advisory
+    web: https://nwc-advisory.com
+issued_time: 2026-03
+sources:
+  - name: HM Land Registry Price Paid Data (England & Wales)
+    access_url: https://www.gov.uk/government/collections/price-paid-data
+  - name: DVF — Demandes de Valeurs Foncieres (France)
+    access_url: https://www.data.gouv.fr/fr/datasets/demandes-de-valeurs-foncieres/
+  - name: HDB Resale Flat Prices (Singapore)
+    access_url: https://data.gov.sg/datasets/d_8b84c4ee58e3cfc0ece0d773c8ca6abc/view
+  - name: NYC Department of Finance Rolling Sales
+    access_url: https://www.nyc.gov/site/finance/about/open-portal.page
+  - name: Dubai Land Department Transactions
+    access_url: https://dubailand.gov.ae/en/open-data/
+  - name: Property Price Register (Ireland)
+    access_url: https://www.propertypriceregister.ie/
+references:
+  - title: API Documentation (Swagger UI)
+    reference: https://api.nwc-advisory.com/docs
+  - title: OpenAPI 3.1 Specification
+    reference: https://api.nwc-advisory.com/openapi.json
+  - title: Available Markets
+    reference: https://api.nwc-advisory.com/markets

--- a/core/Economics/Statistics-of-the-World.yml
+++ b/core/Economics/Statistics-of-the-World.yml
@@ -1,0 +1,8 @@
+---
+title: Statistics of the World
+homepage: https://statisticsoftheworld.com/api-docs
+category: Economics
+description: Free API and interactive platform for 440+ economic, demographic, health, and environmental indicators across 218 countries. Data sourced from IMF World Economic Outlook, World Bank WDI, WHO Global Health Observatory, FRED, and United Nations. JSON API with no authentication required for basic use.
+organization:
+  - name: Statistics of the World
+    web: https://statisticsoftheworld.com

--- a/core/Finance/Helium.yml
+++ b/core/Finance/Helium.yml
@@ -1,0 +1,27 @@
+---
+title: Helium
+homepage: https://heliumtrades.com/mcp-page/
+category: Finance
+description: Real-time news articles with political bias scoring (3.2M+ articles, 5,000+ sources), live stock, ETF, and cryptocurrency market data, AI-assisted options pricing, and multi-source news synthesis. Free API access; MCP integration available for programmatic use.
+version:
+keywords: news, bias, stocks, ETF, cryptocurrency, options, market data, API, MCP, finance
+image:
+temporal: real-time
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity: real-time
+specification: https://heliumtrades.com/mcp-page/
+data_quality: false
+data_dictionary:
+language: en
+license:
+publisher:
+  - name: Helium Trades
+    web: https://heliumtrades.com
+organization:
+issued_time:
+sources:
+references:
+  - title: Helium MCP server
+    reference: https://github.com/connerlambden/helium-mcp

--- a/core/Finance/PredScope-Prediction-Markets.yml
+++ b/core/Finance/PredScope-Prediction-Markets.yml
@@ -1,0 +1,31 @@
+---
+title: PredScope Prediction Markets API
+homepage: https://predscope.com/api/
+category: Finance
+description: Free public API providing 600+ live prediction market events aggregated from Polymarket, including real-time prices, probabilities, and trading volumes. Includes endpoints for live markets (markets.json) and resolved market outcomes (resolved.json). Useful for research on crowd-sourced forecasting, political and economic predictions, and event-driven data.
+version:
+keywords: prediction markets, forecasting, polymarket, crowd wisdom, event contracts, political data, probability
+image:
+temporal: real-time
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity: real-time
+specification: https://predscope.com/api/
+data_quality: false
+data_dictionary: https://predscope.com/api/
+language: en
+license: public
+publisher:
+  - name: PredScope
+    web: https://predscope.com
+organization:
+issued_time:
+sources:
+  - name: Polymarket
+    access_url: https://polymarket.com
+references:
+  - title: Live Markets API
+    reference: https://predscope.com/api/markets.json
+  - title: Resolved Markets API
+    reference: https://predscope.com/api/resolved.json

--- a/core/Finance/Webb-Database.yml
+++ b/core/Finance/Webb-Database.yml
@@ -1,0 +1,21 @@
+---
+title: Webb Database
+homepage: https://webb-database.com
+category: Finance
+description: Aggregates and structures public financial data from HKEX, the SFC, the Hong Kong Law Society, UK Companies House, and other official sources. It provides organized, searchable datasets on listed companies, corporate entities, and related financial information, many in machine-readable formats.
+version: 1.0
+keywords:
+image:
+temporal:
+spatial:
+access_level:
+copyrights:
+accrual_periodicity:
+specification:
+data_dictionary:
+language:
+license:
+publisher:
+organization:
+issued_time:
+sources: []

--- a/core/Government/Poland-Public-Tenders-BZP-TED.yml
+++ b/core/Government/Poland-Public-Tenders-BZP-TED.yml
@@ -1,0 +1,35 @@
+---
+title: Poland Public Tenders Dataset (BZP + TED)
+homepage: https://github.com/atlasprzetargow/polish-tenders-dataset
+category: Government
+description: Open dataset of Polish public procurement notices aggregated from official sources — BZP (Biuletyn Zamówień Publicznych, Polish national procurement bulletin) and TED (Tenders Electronic Daily, EU-wide procurement database). Covers 2024 onward with ~1.4 million tender notices, ~23k buyer profiles and ~82k contractor profiles. Natural-person contractors (sole proprietors) are anonymized via a stable salted SHA-256 hash to comply with Polish/EU data protection law. Deduplication between BZP and TED is flagged, province codes normalized to NUTS-2, cities geocoded. Parquet (git-tracked) + gzipped CSV (release assets).
+version: "2026.Q2"
+keywords: procurement, public procurement, government contracts, Poland, BZP, TED, OCDS, eForms, NUTS-2, CPV, open data, tenders, public sector, transparency
+image:
+temporal: 2024-present
+spatial: Poland (all 16 voivodeships / NUTS-2 regions)
+access_level: public
+copyrights: Atlas Przetargów
+accrual_periodicity: quarterly
+specification: https://github.com/atlasprzetargow/polish-tenders-dataset/tree/main/schema
+data_quality: true
+data_dictionary: https://github.com/atlasprzetargow/polish-tenders-dataset/blob/main/schema/tenders.md
+language: pl, en
+license: CC-BY-4.0
+publisher:
+  - name: Atlas Przetargów
+    web: https://atlasprzetargow.pl
+organization:
+issued_time: "2026-04-17"
+sources:
+  - name: BZP (Biuletyn Zamówień Publicznych)
+    web: https://ezamowienia.gov.pl
+  - name: TED (Tenders Electronic Daily)
+    web: https://ted.europa.eu
+references:
+  - title: Launch blog post (methodology, PII anonymization, use cases)
+    reference: https://atlasprzetargow.pl/blog/open-data-polskich-przetargow-2024-2025
+  - title: Getting started notebook (pandas + DuckDB, market concentration analysis)
+    reference: https://github.com/atlasprzetargow/polish-tenders-dataset/blob/main/notebooks/01_getting_started.ipynb
+  - title: CITATION.cff
+    reference: https://github.com/atlasprzetargow/polish-tenders-dataset/blob/main/CITATION.cff

--- a/core/Government/Saudi-Arabia-Real-Estate-Open-Data.yml
+++ b/core/Government/Saudi-Arabia-Real-Estate-Open-Data.yml
@@ -1,0 +1,39 @@
+---
+title: Saudi Arabia Real Estate Open Data (MOJ + REGA)
+homepage: https://github.com/civillizard/Saudi-Real-Estate-Data
+category: Government
+description: >
+  4.96M real estate transactions from Saudi Arabia's Ministry of Justice (MOJ) 
+  and Real Estate General Authority (REGA). Covers property sales, mortgages, 
+  seizures, and 18 additional RE operation categories across all 13 regions, 
+  plus quarterly rental and sales indicators. 170 CSV files, 627 MB.
+version: 1.0
+keywords: >
+  Saudi Arabia, real estate, property transactions, rentals, 
+  Ministry of Justice, REGA, open data, housing, Vision 2030
+image:
+temporal: 2018-2025
+spatial: Saudi Arabia (13 regions)
+access_level: public
+copyrights:
+accrual_periodicity: Monthly (MOJ), Quarterly (REGA)
+specification:
+data_quality: true
+data_dictionary: DATA_DICTIONARY.md
+language: en, ar
+license: MIT
+publisher:
+  - name: Ministry of Justice, Saudi Arabia
+    web: https://www.moj.gov.sa
+  - name: Real Estate General Authority (REGA), Saudi Arabia
+    web: https://www.rega.gov.sa
+organization:
+  - name: civillizard
+    web: https://github.com/civillizard
+issued_time: 2026.03
+sources:
+  - name: MOJ Open Data Portal
+    access_url: https://www.moj.gov.sa
+  - name: REGA Open Data
+    access_url: https://www.rega.gov.sa
+references: []

--- a/core/Government/UK-Food-Hygiene-Rating-Scheme-FHRS-API.yml
+++ b/core/Government/UK-Food-Hygiene-Rating-Scheme-FHRS-API.yml
@@ -1,0 +1,31 @@
+---
+title: UK Food Hygiene Rating Scheme (FHRS) API
+homepage: https://api.ratings.food.gov.uk/
+category: Government
+description: Food hygiene ratings for 600,000+ food establishments across England, Wales, Northern Ireland, and Scotland. Includes business details, inspection scores, rating history, and geolocation. RESTful API with no authentication required.
+version:
+keywords: food safety, hygiene ratings, restaurants, UK, inspections, food standards agency
+image:
+temporal:
+spatial: United Kingdom
+access_level: public
+copyrights:
+accrual_periodicity: daily
+specification: https://api.ratings.food.gov.uk/help
+data_quality: false
+data_dictionary:
+language: en
+license: Open Government Licence v3.0
+publisher:
+  - name: Food Standards Agency
+    web: https://www.food.gov.uk/
+organization:
+  - name: Food Standards Agency
+    web: https://www.food.gov.uk/
+issued_time:
+sources:
+  - name: FSA FHRS API
+    access_url: https://api.ratings.food.gov.uk/
+references:
+  - title: FHRS API Documentation
+    reference: https://api.ratings.food.gov.uk/help

--- a/core/MachineLearning/BenchGecko-AI-Model-Benchmarks.yml
+++ b/core/MachineLearning/BenchGecko-AI-Model-Benchmarks.yml
@@ -1,0 +1,31 @@
+---
+title: BenchGecko AI Model Benchmarks
+homepage: https://benchgecko.ai
+category: MachineLearning
+description: Benchmark scores, pricing, and capabilities for 414+ AI models across 40 evaluations (MMLU, HumanEval, GSM8K, etc.). Free REST API at benchgecko.ai/api/v1.
+version: 1.0
+keywords: AI benchmarks, LLM, machine learning, model comparison, pricing
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license:
+publisher:
+  - name:
+    web:
+organization:
+  - name: BenchGecko
+    web: https://benchgecko.ai
+issued_time:
+sources:
+  - name: BenchGecko API
+    access_url: https://benchgecko.ai/api/v1
+references:
+  - title:
+    reference:

--- a/core/MachineLearning/BenchGecko-AI-Model-Benchmarks.yml
+++ b/core/MachineLearning/BenchGecko-AI-Model-Benchmarks.yml
@@ -2,7 +2,7 @@
 title: BenchGecko AI Model Benchmarks
 homepage: https://benchgecko.ai
 category: MachineLearning
-description: Benchmark scores, pricing, and capabilities for 414+ AI models across 40 evaluations (MMLU, HumanEval, GSM8K, etc.). Free REST API at benchgecko.ai/api/v1.
+description: Benchmark scores, pricing, and capabilities for 414+ AI models across 40 evaluations (MMLU, HumanEval, GSM8K, etc.). Free REST API documented at benchgecko.ai/api-docs.
 version: 1.0
 keywords: AI benchmarks, LLM, machine learning, model comparison, pricing
 image:
@@ -24,8 +24,12 @@ organization:
     web: https://benchgecko.ai
 issued_time:
 sources:
-  - name: BenchGecko API
-    access_url: https://benchgecko.ai/api/v1
+  - name: BenchGecko API Documentation
+    access_url: https://benchgecko.ai/api-docs
+  - name: Models endpoint
+    access_url: https://benchgecko.ai/api/v1/models
+  - name: Benchmarks endpoint
+    access_url: https://benchgecko.ai/api/v1/benchmarks
 references:
   - title:
     reference:

--- a/core/SearchEngines/Dateno.yml
+++ b/core/SearchEngines/Dateno.yml
@@ -1,0 +1,31 @@
+---
+title: Dateno
+homepage: https://dateno.io
+category: SearchEngines
+description: Dataset search engine for for 5k data sources with 22m datasets across the World includes open data, statistics and geodata.
+version: 1.0
+keywords: open data, datasets, datasets search, data search, geodata, statistics
+image: https://avatars.githubusercontent.com/u/181207829?s=200&v=4
+temporal:
+spatial: 
+access_level: public
+copyrights:
+accrual_periodicity: 
+specification:
+data_quality: false
+data_dictionary: 
+language: en
+license: Apache License
+publisher:
+  - name: Dateno 
+    web: https://dateno.io
+organization:
+  - name: Dateno LLC
+    web: https://dateno.io
+issued_time: 2023.09
+sources:
+  - name: 
+    access_url: 
+references:
+  - title: 
+    reference: 

--- a/core/SocialSciences/Measured-World.yml
+++ b/core/SocialSciences/Measured-World.yml
@@ -1,0 +1,25 @@
+---
+title: Measured World
+homepage: https://measuredworld.com
+category: SocialSciences
+description: >
+  Demographic, economic, education, and energy data for up to 237 countries
+  and territories. 147 indicators sourced from UN Population Division, IMF,
+  UNESCO, and EIA, with coverage varying by category.
+version:
+keywords:
+image:
+temporal:
+spatial:
+access_level:
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language:
+license:
+publisher:
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
---
title: 38-Cloud
homepage: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset
category: EarthScience
description: Contains 38 Landsat 8 scene images and their manually extracted pixel-level ground truths for cloud detection. They are cropped into multiple 384*384 patches. It has 8400 patches for training and 9201 patches for testing.
version: 1.0
keywords: Landsat 8, cloud detection, image segmentation, semantic segmentation.
image: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset/blob/master/sample/blue_patch_192_10_by_12_LC08_L1TP_002053_20160520_20170324_01_T1.jpg
temporal:
spatial: 384*384
access_level: public
copyrights:
accrual_periodicity: 
specification:
data_quality: false
data_dictionary: 
language: en
license: Apache License
publisher:
  - name: 
    web: 
organization:
  - name: Laboratory for Robotic Vision (LRV), School of Engineering Science, Simon Fraser University, Canada
    web: 
issued_time: 2019.02
sources:
  - name: 
    access_url: 
references:
  - title: 
    reference: 
